### PR TITLE
Fix database bug

### DIFF
--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -300,15 +300,14 @@ check_rt_login <- function(rt_base) {
 #'                                  \n The Arctic Data Center Support Team", 
 #'                                  test = TRUE)
 #' }
-
 create_new_ticket_correspondence <- function(db, template, test = TRUE) {
   
   for (i in seq_len(nrow(db))) {
 
     if(test){
-      db$rt_ticket[i] <- awardsBot:::create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
+      db$rt_ticket[i] <- create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
     } else {
-      db$rt_ticket[i] <- awardsBot:::create_ticket(db$id[i], db$pi_email[i])
+      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
     }
     
     
@@ -322,7 +321,7 @@ create_new_ticket_correspondence <- function(db, template, test = TRUE) {
                           db$id[i],
                           db$title[i])
     
-    reply <- awardsBot:::check_rt_reply(db$rt_ticket[i], email_text)
+    reply <- check_rt_reply(db$rt_ticket[i], email_text)
 
     db$contact_initial[i] <- as.character(Sys.Date())
     

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -294,11 +294,11 @@ check_rt_login <- function(rt_base) {
 #' @examples 
 #' \dontrun{
 #' db <- import_awards_db(file.path(system.file('example_db.csv', package = 'awardsBot')))
+#' email_text <-  "Dear %s,  \n We are writing to you today about your NSF Arctic Sciences award %s %s. 
+#'                 \n The Arctic Data Center Support Team"
 #' create_new_ticket_correspondence(db = db, 
-#'                                  "Dear %s, 
-#'                                  \n We are writing to you today about your NSF Arctic Sciences award %s %s. 
-#'                                  \n The Arctic Data Center Support Team", 
-#'                                  test = TRUE)
+#'                                 email_text, 
+#'                                 test = TRUE)
 #' }
 create_new_ticket_correspondence <- function(db, template, test = TRUE) {
   

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -79,7 +79,7 @@ create_ticket_and_send_initial_correspondence <- function(awards_db, database_pa
     db$contact_initial[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i,]
+    awards_db[indicies[i],] <- db[i,]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -112,7 +112,7 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
     db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -148,7 +148,7 @@ send_aon_correspondence <- function(awards_db, database_path){
     db$contact_aon_previous[i] <- db$contact_aon_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -181,7 +181,7 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
     db$contact_1mo[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -79,7 +79,7 @@ create_ticket_and_send_initial_correspondence <- function(awards_db, database_pa
     db$contact_initial[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i,]
+    awards_db[indices[i],] <- db[i,]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -112,7 +112,7 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
     db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -148,7 +148,7 @@ send_aon_correspondence <- function(awards_db, database_path){
     db$contact_aon_previous[i] <- db$contact_aon_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -181,7 +181,7 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
     db$contact_1mo[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -284,7 +284,7 @@ check_rt_login <- function(rt_base) {
 #' Similar to a mail merge for sending mass emails to RT.
 #'
 #' @param db (dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title
-#' @param template (character) an email template that will fill in the name and award title at each %s (see example below)
+#' @param template (character) an email template that will fill in the name and award title at each \%s (see example below)
 #' @param test (logical) sends a test email (replaces all the emails with a test email address)
 #' 
 #'

--- a/R/main.R
+++ b/R/main.R
@@ -7,7 +7,7 @@
 #' @param initial_aon_offset (numeric)Number of months after award startDate to send first AON data due reminder
 #' @param aon_recurring_interval (numeric) Number of months to send recurring emails for AON data due
 #'
-#' @return
+#' @return nothing
 #' @export
 #'
 #' @examples
@@ -53,7 +53,7 @@ main <- function(database_path = Sys.getenv('DATABASE_PATH'),
 #' @param aon_recurring_interval (numeric) Number of months to send recurring emails for AON data due
 #' @param email The email to send the tickets to
 #'
-#' @return
+#' @return nothing
 #' @export
 #'
 #' @examples

--- a/R/testing_functions.R
+++ b/R/testing_functions.R
@@ -65,10 +65,10 @@ create_dummy_database <- function() {
   #make 2  more rows
   db <- rbind(db[1,], db[1,], db[1,])
   
-  db$id[2] <- "7654321"
+  db$id[1] <- "7654321"
   db$id[3] <- "9999999"
   
-  db$active_award_flag[1] <- "yes"
+  db$active_award_flag[2] <- "yes"
   
   return(db)
 }

--- a/R/testing_functions.R
+++ b/R/testing_functions.R
@@ -60,6 +60,15 @@ create_dummy_database <- function() {
   db$fund_program_name <- 'ARCTIC NATURAL SCIENCES'
   db$id <- '1234567'  # NSF award number 
   db$start_date <- '2016-01-01'
+  db$active_award_flag <- "no"
+  
+  #make 2  more rows
+  db <- rbind(db[1,], db[1,], db[1,])
+  
+  db$id[2] <- "7654321"
+  db$id[3] <- "9999999"
+  
+  db$active_award_flag[1] <- "yes"
   
   return(db)
 }

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -23,10 +23,10 @@ Similar to a mail merge for sending mass emails to RT.
 \examples{
 \dontrun{
 db <- import_awards_db(file.path(system.file('example_db.csv', package = 'awardsBot')))
+email_text <-  "Dear \%s,  \n We are writing to you today about your NSF Arctic Sciences award \%s \%s. 
+                \n The Arctic Data Center Support Team"
 create_new_ticket_correspondence(db = db, 
-                                 "Dear \%s, 
-                                 \n We are writing to you today about your NSF Arctic Sciences award \%s \%s. 
-                                 \n The Arctic Data Center Support Team", 
-                                 test = TRUE)
+                                email_text, 
+                                test = TRUE)
 }
 }

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -2,14 +2,14 @@
 % Please edit documentation in R/RT_functions.R
 \name{create_new_ticket_correspondence}
 \alias{create_new_ticket_correspondence}
-\title{Generalized version of the create_ticket and send correspondence function}
+\title{Generalized version of the create_ticket and send_correspondences function}
 \usage{
 create_new_ticket_correspondence(db, template, test = TRUE)
 }
 \arguments{
 \item{db}{(dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title}
 
-\item{template}{(character)}
+\item{template}{(character) an email template that will fill in the name and award title at each %s (see example below)}
 
 \item{test}{(logical) sends a test email (replaces all the emails with a test email address)}
 }

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -9,7 +9,7 @@ create_new_ticket_correspondence(db, template, test = TRUE)
 \arguments{
 \item{db}{(dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title}
 
-\item{template}{(character) an email template that will fill in the name and award title at each %s (see example below)}
+\item{template}{(character) an email template that will fill in the name and award title at each \%s (see example below)}
 
 \item{test}{(logical) sends a test email (replaces all the emails with a test email address)}
 }

--- a/man/main.Rd
+++ b/man/main.Rd
@@ -27,7 +27,7 @@ main(
 \item{aon_recurring_interval}{(numeric) Number of months to send recurring emails for AON data due}
 }
 \value{
-
+nothing
 }
 \description{
 main function

--- a/man/test_main.Rd
+++ b/man/test_main.Rd
@@ -32,7 +32,7 @@ test_main(
 \item{email}{The email to send the tickets to}
 }
 \value{
-
+nothing
 }
 \description{
 Test main function

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -2,6 +2,7 @@ library(rt)
 context('Send RT correspondences')
 
 rt_url <- 'https://support.nceas.ucsb.edu/rt'
+db_path<- tempfile()
 
 ## TODO these tests could be improved with an rt::get_last_correspondence_text function
 
@@ -25,7 +26,7 @@ test_that('we can send an initial correspondence', {
   
   db <- create_dummy_database()
 
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
   ticket <- rt::rt_ticket_properties(db$rt_ticket)
   expect_equal(ticket$Requestors, 'jasminelai@nceas.ucsb.edu')
@@ -37,9 +38,9 @@ test_that('we can send an annual report correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_annual_report_next <- as.character(Sys.Date())
-  db <- send_annual_report_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_annual_report_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_annual_report_next, db$contact_annual_report_previous)
 })
@@ -50,10 +51,10 @@ test_that('we can send a one month remaining correspondence',{
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   # Set expiration date to one month from now
   db$contact_1mo <- as.character(Sys.Date())
-  db <- send_one_month_remaining_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_1mo, as.character(Sys.Date()))
 })
@@ -64,9 +65,9 @@ test_that('we can send an aon correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_aon_next <- as.character(Sys.Date())
-  db <- send_aon_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)
 })
@@ -81,7 +82,7 @@ test_that('check_rt_reply catches both potential errors', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
   template <- read_initial_template(db$fund_program_name[1])
   email_text <- sprintf(template,

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -28,7 +28,7 @@ test_that('we can send an initial correspondence', {
 
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
-  ticket <- rt::rt_ticket_properties(db$rt_ticket)
+  ticket <- rt::rt_ticket_properties(db$rt_ticket[2])
   expect_equal(ticket$Requestors, 'jasminelai@nceas.ucsb.edu')
 })
 
@@ -39,10 +39,10 @@ test_that('we can send an annual report correspondence', {
   
   db <- create_dummy_database()
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
-  db$contact_annual_report_next <- as.character(Sys.Date())
+  db$contact_annual_report_next[2] <- as.character(Sys.Date())
   db <- send_annual_report_correspondence(db, database_path = db_path)
   
-  expect_equal(db$contact_annual_report_next, db$contact_annual_report_previous)
+  expect_equal(db$contact_annual_report_next[2], db$contact_annual_report_previous[2])
 })
 
 test_that('we can send a one month remaining correspondence',{
@@ -56,7 +56,7 @@ test_that('we can send a one month remaining correspondence',{
   db$contact_1mo <- as.character(Sys.Date())
   db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
-  expect_equal(db$contact_1mo, as.character(Sys.Date()))
+  expect_equal(db$contact_1mo[2], as.character(Sys.Date()))
 })
 
 test_that('we can send an aon correspondence', {
@@ -66,7 +66,7 @@ test_that('we can send an aon correspondence', {
   
   db <- create_dummy_database()
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
-  db$contact_aon_next <- as.character(Sys.Date())
+  db$contact_aon_next[2] <- as.character(Sys.Date())
   db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)


### PR DESCRIPTION
- `indices[i]` instead of `i` so that the rows are re-inserted in the right place. The previous behavior was overwriting rows and was not caught because the tests only used a test database with 1 row where this is not an issue.
- updated the tests to use a database with 3 rows but only 1 active award so only one ticket will be created