### PR TITLE
Accommodate cases where there is no initial email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: awardsBot
 Type: Package
 Title: Periodic Correspondence Bot for NSF Award Recipients
 Version: 1.0
-Date: 2018-06-18
+Date: 2021-08-12
 Authors@R: c(
   person("Dominic", "Mullen", email = "dmullen17@gmail.com", role = c("cre", "aut")),
   person("Mitchell", "Maier", email = "mitchell.maier@gmail.com", role = c("ctb")),

--- a/R/RT_check_correspondence.R
+++ b/R/RT_check_correspondence.R
@@ -12,37 +12,39 @@
 #' }
 get_recent_incoming_correspondence <- function(ticket_id, after) {
   correspondences <- list()
-
+  
   req <- rt::rt_ticket_history(ticket_id, format = "s")
-
+  
   if (req$status != 200) {
     out <- "Failed to log into RT"
+    
     slackr::slackr_bot(out)
     stop(out)
   }
-
+  
   # look for all instances with an email
   ticket_history <- unlist(strsplit(req$body, "\\n"))
-  incoming <- ticket_history[stringr::str_detect(ticket_history, "Correspondence added by .+@.+")]
-
+  incoming <-
+    ticket_history[stringr::str_detect(ticket_history, "Correspondence added by .+@.+")]
+  
   if (length(incoming) == 0) {
     return(correspondences)
   }
-
+  
   for (inc in incoming) {
-
     # get the specific correspondence
     id <- stringr::str_extract(inc, "[0-9]*")
-
+    
     response <- rt::rt_ticket_history_entry(ticket_id, id)
-
+    
     if (response$Created <= after) {
       next
     }
-
-    correspondences <- append(correspondences, format_history_entry(response))
+    
+    correspondences <-
+      append(correspondences, format_history_entry(response))
   }
-
+  
   return(correspondences)
 }
 
@@ -60,18 +62,20 @@ get_recent_incoming_correspondence <- function(ticket_id, after) {
 #' format_history_entry(response)
 #' }
 format_history_entry <- function(msg, trunc_at = 200) {
-
   if (msg["Type"] == "Correspond") {
     msg["Type"] <- "Correspondence"
   } else if (msg["Type"] == "Create") {
     msg["Type"] <- "Ticket created"
   }
-
+  
   # construct the slack message
   sprintf(
     "%s by %s on <%s/Ticket/Display.html?id=%s|Ticket %s>:\n>%s",
-    msg$Type, msg$Creator, Sys.getenv("RT_BASE_URL"),
-    msg$Ticket, msg$Ticket,
+    msg$Type,
+    msg$Creator,
+    Sys.getenv("RT_BASE_URL"),
+    msg$Ticket,
+    msg$Ticket,
     stringr::str_trunc(stringr::str_remove_all(msg$Content, "\\n\\s+"), trunc_at)
   )
 }
@@ -89,9 +93,11 @@ format_history_entry <- function(msg, trunc_at = 200) {
 #' get_tickets_with_new_incoming_correspondence("2021-05-03")
 #' }
 get_tickets_with_new_incoming_correspondence <- function(after) {
-  tickets <- rt::rt_ticket_search(paste0("Queue='arcticAwards' AND LastUpdated >'", after, " 00:00:00'"))
-
+  tickets <-
+    rt::rt_ticket_search(paste0("Queue='arcticAwards' AND LastUpdated >'", after, " 00:00:00'"))
+  
   if (nrow(tickets) > 0) {
-    correspondence <- lapply(tickets$id, get_recent_incoming_correspondence, after)
+    correspondence <-
+      lapply(tickets$id, get_recent_incoming_correspondence, after)
   }
 }

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -111,10 +111,6 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
       # Create RT ticket
       db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
       
-      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-        next 
-      }
-      
     }
     
     reply <- check_rt_reply(db$rt_ticket[i], email_text)
@@ -158,10 +154,6 @@ send_aon_correspondence <- function(awards_db, database_path){
       # Create RT ticket
       db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
       
-      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-        next 
-      }
-      
     }
     
     reply <- check_rt_reply(db$rt_ticket[i], email_text)
@@ -200,10 +192,6 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
     if(is.na(db$rt_ticket[i])){
       # Create RT ticket
       db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
-      
-      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-        next 
-      }
       
     }
     
@@ -269,25 +257,6 @@ check_rt_reply <- function(ticket_number, email) {
   
   return(ticket)
 } 
-
-## helper function to 
-reply_rt_ticket <- function(){
-  
-  
-  if(is.na(db$rt_ticket[i])){
-    # Create RT ticket
-    db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
-    
-    if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-      next 
-    }
-    
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
-    
-  } else {
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
-  }
-}
 
 ## helper function to read in email templates
 read_file <- function(path) {

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -1,156 +1,178 @@
 #' Wrapper function that sends all correspondences
-#' 
+#'
 #' Wrapper function for 'create_ticket_and_send_initial_correspondence',
 #' 'send_annual_report_correspondence', 'send_aon_correspondence', and
 #' 'send_one_month_remaining_correspondence'
-#' 
+#'
 #' @param awards_db (data.frame) awards database
 #' @param database_path (character) the path to save the database to
-#' 
-#' @importFrom magrittr '%>%' 
+#'
+#' @importFrom magrittr '%>%'
 send_correspondences <- function(awards_db, database_path) {
-  
-  awards_db <- create_ticket_and_send_initial_correspondence(awards_db, database_path) %>%
+  awards_db <-
+    create_ticket_and_send_initial_correspondence(awards_db, database_path) %>%
     send_annual_report_correspondence(., database_path) %>%
     send_aon_correspondence(., database_path) %>%
-    send_one_month_remaining_correspondence(., database_path) 
+    send_one_month_remaining_correspondence(., database_path)
   
   return(awards_db)
 }
 
 #' Create New Tickets
-#' 
+#'
 #' Run this code to create a new RT ticket based off NSF award number and requestor
-#' (PI) email.  Requires a valid RT login in order to run.  
+#' (PI) email.  Requires a valid RT login in order to run.
 #'
 #' @param award (character) NSF award number.
 #' @param requestor (character) PI email
-#' 
+#'
 #' @return ticket_id (character) Newly generated RT ticket id
 create_ticket <- function(award, requestor) {
   subject <- sprintf('Arctic Data Center NSF Award: %s',  award)
-  ticket <- rt::rt_ticket_create(queue = 'arcticAwards',
-                                 requestor = requestor,
-                                 subject = subject,
-                                 rt_base = 'https://support.nceas.ucsb.edu/rt')
+  ticket <- rt::rt_ticket_create(
+    queue = 'arcticAwards',
+    requestor = requestor,
+    subject = subject,
+    rt_base = 'https://support.nceas.ucsb.edu/rt'
+  )
   
   #check to see if the object ticket is created successfully
-  if(!exists("ticket")) {
-    out <- sprintf('I failed to create a ticket for award: %s, from requestor: %s', award, requestor)	
-    slackr::slackr_bot(out)	
-    return('rt_ticket_create_error')	
+  if (!exists("ticket")) {
+    out <-
+      sprintf('I failed to create a ticket for award: %s, from requestor: %s',
+              award,
+              requestor)
+    slackr::slackr_bot(out)
+    return('rt_ticket_create_error')
   }
-
+  
   return(ticket)
 }
 
 
-#' Create New Tickets and send initial correspondences 
-#' 
-#' Run this code to create new RT tickets and send an initial correspondence, based 
+#' Create New Tickets and send initial correspondences
+#'
+#' Run this code to create new RT tickets and send an initial correspondence, based
 #' off a database of new NSF awards.  The database must include: fund_program_name,
-#' pi_email, pi_first_name, id (NSF award #), title (NSF award title).  
+#' pi_email, pi_first_name, id (NSF award #), title (NSF award title).
 #'
 #' @param awards_db (data.frame) database of NSF awards pulled from NSF-API
 #' @param database_path (character) the path to save the database to
 #'
 #' @return awards_db (data.frame) The initial database with updated RT ticket numbers
-create_ticket_and_send_initial_correspondence <- function(awards_db, database_path) {
-  # Get awards without an initial correspondence
-  indices <- which(is.na(awards_db$contact_initial) & awards_db$active_award_flag == 'yes') # save indices to re-merge
-  db <- awards_db[indices,]
-  
-  for (i in seq_len(nrow(db))) {
-    # Create RT ticket
-    db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+create_ticket_and_send_initial_correspondence <-
+  function(awards_db, database_path) {
+    # Get awards without an initial correspondence
+    indices <-
+      which(is.na(awards_db$contact_initial) &
+              awards_db$active_award_flag == 'yes') # save indices to re-merge
+    db <- awards_db[indices,]
     
-    if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-      next 
-    }
-    # Create correspondence text 
-    template <- read_initial_template(db$fund_program_name[i])
-    email_text <- sprintf(template,
-                          db$pi_first_name[i],
-                          db$id[i],
-                          db$title[i])
-    
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
-    
-    db$contact_initial[i] <- as.character(Sys.Date())
-    
-    # re-merge temporary database into permanent
-    awards_db[indices[i],] <- db[i,]
-    #save the result inbetween
-    utils::write.csv(awards_db, file = database_path, row.names = FALSE)
-  }
-  
-  #send summary of tickets created
-  if(nrow(db) >= 0) {
-    out <- sprintf('I created %s new ticket(s) today', nrow(db))	
-    slackr::slackr_bot(out)	
-  }
-  
-  return(awards_db)
-}
-
-
-send_annual_report_correspondence <- function(awards_db, database_path) {
-  # Get awards to send annual report correspondence 
-  current_date <- as.character(Sys.Date())
-  indices <- which(awards_db$contact_annual_report_next == current_date & awards_db$active_award_flag == 'yes') # save indices to re-merge
-  db <- awards_db[indices,]
-  
-  for (i in seq_len(nrow(db))) {
-    # Create correspondence text 
-    template <- read_file(file.path(system.file('emails', 'contact_annual_report', package = 'awardsBot')))
-    email_text <- sprintf(template,
-                          db$pi_first_name[i])
-    
-    #deals with cases where an initial ticket was not created
-    if(is.na(db$rt_ticket[i])){
+    for (i in seq_len(nrow(db))) {
       # Create RT ticket
       db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
       
+      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+        next
+      }
+      # Create correspondence text
+      template <- read_initial_template(db$fund_program_name[i])
+      email_text <- sprintf(template,
+                            db$pi_first_name[i],
+                            db$id[i],
+                            db$title[i])
+      
+      reply <- check_rt_reply(db$rt_ticket[i], email_text)
+      
+      db$contact_initial[i] <- as.character(Sys.Date())
+      
+      # re-merge temporary database into permanent
+      awards_db[indices[i],] <- db[i,]
+      #save the result inbetween
+      utils::write.csv(awards_db, file = database_path, row.names = FALSE)
     }
     
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
+    #send summary of tickets created
+    if (nrow(db) >= 0) {
+      out <- sprintf('I created %s new ticket(s) today', nrow(db))
+      slackr::slackr_bot(out)
+    }
     
-    # Update last contact date
-    db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
-    
-    # re-merge temporary database into permanent
-    awards_db[indices[i],] <- db[i, ]
-    #save the result inbetween
-    utils::write.csv(awards_db, file = database_path, row.names = FALSE)
+    return(awards_db)
   }
-  
-  #send summary of tickets created
-  if(nrow(db) > 0) {
-    out <- sprintf('I sent %s annual reminder(s) today', nrow(db))	
-    slackr::slackr_bot(out)	
-  }
-  
-  ## TODO
-  # add function that updates annual report correspondence times
-  
-  
-  return(awards_db)
-}
 
 
-send_aon_correspondence <- function(awards_db, database_path){
+send_annual_report_correspondence <-
+  function(awards_db, database_path) {
+    # Get awards to send annual report correspondence
+    current_date <- as.character(Sys.Date())
+    indices <-
+      which(
+        awards_db$contact_annual_report_next == current_date &
+          awards_db$active_award_flag == 'yes'
+      ) # save indices to re-merge
+    db <- awards_db[indices,]
+    
+    for (i in seq_len(nrow(db))) {
+      # Create correspondence text
+      template <-
+        read_file(file.path(
+          system.file('emails', 'contact_annual_report', package = 'awardsBot')
+        ))
+      email_text <- sprintf(template,
+                            db$pi_first_name[i])
+      
+      #deals with cases where an initial ticket was not created
+      if (is.na(db$rt_ticket[i])) {
+        # Create RT ticket
+        db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+        
+      }
+      
+      reply <- check_rt_reply(db$rt_ticket[i], email_text)
+      
+      # Update last contact date
+      db$contact_annual_report_previous[i] <-
+        db$contact_annual_report_next[i]
+      
+      # re-merge temporary database into permanent
+      awards_db[indices[i],] <- db[i, ]
+      #save the result inbetween
+      utils::write.csv(awards_db, file = database_path, row.names = FALSE)
+    }
+    
+    #send summary of tickets created
+    if (nrow(db) > 0) {
+      out <- sprintf('I sent %s annual reminder(s) today', nrow(db))
+      slackr::slackr_bot(out)
+    }
+    
+    ## TODO
+    # add function that updates annual report correspondence times
+    
+    
+    return(awards_db)
+  }
+
+
+send_aon_correspondence <- function(awards_db, database_path) {
   current_date <- as.character(Sys.Date())
-  indices <- which(awards_db$contact_aon_next == current_date & awards_db$active_award_flag == 'yes')
+  indices <-
+    which(awards_db$contact_aon_next == current_date &
+            awards_db$active_award_flag == 'yes')
   db <- awards_db[indices,]
   
   for (i in seq_len(nrow(db))) {
-    # Create correspondence text 
-    template <- read_file(file.path(system.file('emails', 'contact_aon_recurring', package = 'awardsBot')))
+    # Create correspondence text
+    template <-
+      read_file(file.path(
+        system.file('emails', 'contact_aon_recurring', package = 'awardsBot')
+      ))
     email_text <- sprintf(template,
                           db$pi_first_name[i])
     
     #deals with cases where an initial ticket was not created
-    if(is.na(db$rt_ticket[i])){
+    if (is.na(db$rt_ticket[i])) {
       # Create RT ticket
       db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
       
@@ -168,95 +190,104 @@ send_aon_correspondence <- function(awards_db, database_path){
   }
   
   #send summary of tickets created
-  if(nrow(db) > 0) {
-    out <- sprintf('I sent %s AON email(s) today', nrow(db))	
-    slackr::slackr_bot(out)	
+  if (nrow(db) > 0) {
+    out <- sprintf('I sent %s AON email(s) today', nrow(db))
+    slackr::slackr_bot(out)
   }
   
   return(awards_db)
 }
 
-  
-send_one_month_remaining_correspondence <- function(awards_db, database_path) {
-  indices <- which(awards_db$contact_1mo == as.character(Sys.Date()) & awards_db$active_award_flag == 'yes')
-  db <- awards_db[indices,]
-  
-  for (i in seq_len(nrow(db))) {
-    # Create correspondence text 
-    template <- read_file(file.path(system.file('emails', 'contact_one_month_remaining', package = 'awardsBot')))
-    email_text <- sprintf(template,
-                          db$pi_first_name[i],
-                          db$id[i],
-                          db$title[i])
+
+send_one_month_remaining_correspondence <-
+  function(awards_db, database_path) {
+    indices <-
+      which(
+        awards_db$contact_1mo == as.character(Sys.Date()) &
+          awards_db$active_award_flag == 'yes'
+      )
+    db <- awards_db[indices,]
     
-    if(is.na(db$rt_ticket[i])){
-      # Create RT ticket
-      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+    for (i in seq_len(nrow(db))) {
+      # Create correspondence text
+      template <-
+        read_file(file.path(
+          system.file('emails', 'contact_one_month_remaining', package = 'awardsBot')
+        ))
+      email_text <- sprintf(template,
+                            db$pi_first_name[i],
+                            db$id[i],
+                            db$title[i])
       
+      if (is.na(db$rt_ticket[i])) {
+        # Create RT ticket
+        db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+        
+      }
+      
+      reply <- check_rt_reply(db$rt_ticket[i], email_text)
+      
+      # Update last contact date
+      db$contact_1mo[i] <- as.character(Sys.Date())
+      
+      # re-merge temporary database into permanent
+      awards_db[indices[i],] <- db[i, ]
+      #save the result inbetween
+      utils::write.csv(awards_db, file = database_path, row.names = FALSE)
     }
     
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
+    #send summary of tickets created
+    if (nrow(db) > 0) {
+      out <- sprintf('I sent %s one month reminder(s) today', nrow(db))
+      slackr::slackr_bot(out)
+    }
     
-    # Update last contact date
-    db$contact_1mo[i] <- as.character(Sys.Date())
-    
-    # re-merge temporary database into permanent
-    awards_db[indices[i],] <- db[i, ]
-    #save the result inbetween
-    utils::write.csv(awards_db, file = database_path, row.names = FALSE)
-  }
-  
-  #send summary of tickets created
-  if(nrow(db) > 0) {
-    out <- sprintf('I sent %s one month reminder(s) today', nrow(db))	
-    slackr::slackr_bot(out)	
+    return(awards_db)
   }
 
-  return(awards_db)
-}
-  
 
 # General function that sends a correspondence based on a specified time
-# 
-#This function sends a correspondence based on a specified time interval from 
+#
+#This function sends a correspondence based on a specified time interval from
 # the startDate or the expDate.  You can specify which direction in time you'd like
 # to go based on the starting point, as well as the time interval in years, months,
-# and days.  
+# and days.
 send_correspondence_at_time_x <- function(awards_db,
                                           starting_point,
                                           direction,
                                           years = 0,
-                                          months = 0, 
+                                          months = 0,
                                           days = 0,
-                                          rtTicket, 
+                                          rtTicket,
                                           email_text) {
   if (!(starting_point %in% c('start_date', 'exp_date'))) {
     stop('starting point must be one of "start_date" or "exp_date"')
   }
   if (!is.numeric(c(years, months, days))) {
     stop('"years", "months", and "days" arguments must be numeric')
-  } 
+  }
   
   db <- awards_db
   dates <- as.Date(db[[starting_point]])
-  time_int <- lubridate::period(c(days, months, years), c('day', 'month', 'year'))
+  time_int <-
+    lubridate::period(c(days, months, years), c('day', 'month', 'year'))
   dates + time_int
   
 }
 
-check_rt_reply <- function(ticket_number, email) {	
+check_rt_reply <- function(ticket_number, email) {
   tryCatch({
     ticket <- rt::rt_ticket_history_reply(ticket_id = ticket_number,
-                                text = email,
-                                rt_base = 'https://support.nceas.ucsb.edu/rt')
+                                          text = email,
+                                          rt_base = 'https://support.nceas.ucsb.edu/rt')
   },
-  error = function(e) { 
-    out <- sprintf('I failed to reply on: %s', ticket)	
+  error = function(e) {
+    out <- sprintf('I failed to reply on: %s', ticket)
     slackr::slackr_bot(out)
   })
   
   return(ticket)
-} 
+}
 
 ## helper function to read in email templates
 read_file <- function(path) {
@@ -268,15 +299,22 @@ read_initial_template <- function(fund_program_name) {
   stopifnot(is.character(fund_program_name))
   
   if (grepl('AON', fund_program_name)) {
-    path <- file.path(system.file('emails', 'contact_initial_aon', package = 'awardsBot'))
+    path <-
+      file.path(system.file('emails', 'contact_initial_aon', package = 'awardsBot'))
   } else if (grepl('SOCIAL', fund_program_name)) {
-    path <- file.path(system.file('emails', 'contact_initial_social_sciences', package = 'awardsBot'))
+    path <-
+      file.path(
+        system.file('emails', 'contact_initial_social_sciences', package = 'awardsBot')
+      )
   } else {
-    path <- file.path(system.file('emails', 'contact_initial_ans', package = 'awardsBot'))
+    path <-
+      file.path(system.file('emails', 'contact_initial_ans', package = 'awardsBot'))
   }
   
   if (!file.exists(path)) {
-    slackr::slackr_bot('I failed to read in a contact_initial email template, please check that the file paths used by "awardsBot::read_initial_template" all exist.')
+    slackr::slackr_bot(
+      'I failed to read in a contact_initial email template, please check that the file paths used by "awardsBot::read_initial_template" all exist.'
+    )
   }
   
   template <- read_file(path)
@@ -284,10 +322,12 @@ read_initial_template <- function(fund_program_name) {
 }
 
 
-## Helper function to check if RT is logged in 
+## Helper function to check if RT is logged in
 check_rt_login <- function(rt_base) {
   base_api <- paste(stringr::str_replace(rt_base, '\\/$', ''),
-                    'REST', '1.0', sep = '/')
+                    'REST',
+                    '1.0',
+                    sep = '/')
   content <- httr::GET(base_api) %>%
     httr::content()
   
@@ -299,53 +339,53 @@ check_rt_login <- function(rt_base) {
 }
 
 #' Generalized version of the create_ticket and send_correspondences function
-#' 
-#' For sending reminder emails or any other mass customized email correspondences. 
+#'
+#' For sending reminder emails or any other mass customized email correspondences.
 #' Similar to a mail merge for sending mass emails to RT.
 #'
 #' @param db (dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title
 #' @param template (character) an email template that will fill in the name and award title at each \%s (see example below)
 #' @param test (logical) sends a test email (replaces all the emails with a test email address)
-#' 
+#'
 #'
 #' @return dataframe
 #' @export
 #'
-#' @examples 
+#' @examples
 #' \dontrun{
 #' db <- import_awards_db(file.path(system.file('example_db.csv', package = 'awardsBot')))
-#' email_text <-  "Dear %s,  \n We are writing to you today about your NSF Arctic Sciences award %s %s. 
+#' email_text <-  "Dear %s,  \n We are writing to you today about your NSF Arctic Sciences award %s %s.
 #'                 \n The Arctic Data Center Support Team"
-#' create_new_ticket_correspondence(db = db, 
-#'                                 email_text, 
+#' create_new_ticket_correspondence(db = db,
+#'                                 email_text,
 #'                                 test = TRUE)
 #' }
-create_new_ticket_correspondence <- function(db, template, test = TRUE) {
-  
-  for (i in seq_len(nrow(db))) {
-
-    if(test){
-      db$rt_ticket[i] <- create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
-    } else {
-      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+create_new_ticket_correspondence <-
+  function(db, template, test = TRUE) {
+    for (i in seq_len(nrow(db))) {
+      if (test) {
+        db$rt_ticket[i] <-
+          create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
+      } else {
+        db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+      }
+      
+      
+      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+        next
+      }
+      
+      #Fill in correspondence text
+      email_text <- sprintf(template,
+                            db$pi_first_name[i],
+                            db$id[i],
+                            db$title[i])
+      
+      reply <- check_rt_reply(db$rt_ticket[i], email_text)
+      
+      db$contact_initial[i] <- as.character(Sys.Date())
+      
+      return(db)
+      
     }
-    
-    
-    if (db$rt_ticket[i] == 'rt_ticket_create_error') {
-      next 
-    }
-   
-     #Fill in correspondence text 
-    email_text <- sprintf(template,
-                          db$pi_first_name[i],
-                          db$id[i],
-                          db$title[i])
-    
-    reply <- check_rt_reply(db$rt_ticket[i], email_text)
-
-    db$contact_initial[i] <- as.character(Sys.Date())
-    
-    return(db)
-
   }
-}

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -300,15 +300,14 @@ check_rt_login <- function(rt_base) {
 #'                                  \n The Arctic Data Center Support Team", 
 #'                                  test = TRUE)
 #' }
-
 create_new_ticket_correspondence <- function(db, template, test = TRUE) {
   
   for (i in seq_len(nrow(db))) {
 
     if(test){
-      db$rt_ticket[i] <- awardsBot:::create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
+      db$rt_ticket[i] <- create_ticket(db$id[i], "jasminelai@nceas.ucsb.edu")
     } else {
-      db$rt_ticket[i] <- awardsBot:::create_ticket(db$id[i], db$pi_email[i])
+      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
     }
     
     
@@ -322,7 +321,7 @@ create_new_ticket_correspondence <- function(db, template, test = TRUE) {
                           db$id[i],
                           db$title[i])
     
-    reply <- awardsBot:::check_rt_reply(db$rt_ticket[i], email_text)
+    reply <- check_rt_reply(db$rt_ticket[i], email_text)
 
     db$contact_initial[i] <- as.character(Sys.Date())
     

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -294,11 +294,11 @@ check_rt_login <- function(rt_base) {
 #' @examples 
 #' \dontrun{
 #' db <- import_awards_db(file.path(system.file('example_db.csv', package = 'awardsBot')))
+#' email_text <-  "Dear %s,  \n We are writing to you today about your NSF Arctic Sciences award %s %s. 
+#'                 \n The Arctic Data Center Support Team"
 #' create_new_ticket_correspondence(db = db, 
-#'                                  "Dear %s, 
-#'                                  \n We are writing to you today about your NSF Arctic Sciences award %s %s. 
-#'                                  \n The Arctic Data Center Support Team", 
-#'                                  test = TRUE)
+#'                                 email_text, 
+#'                                 test = TRUE)
 #' }
 create_new_ticket_correspondence <- function(db, template, test = TRUE) {
   

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -106,8 +106,19 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
     email_text <- sprintf(template,
                           db$pi_first_name[i])
     
+    #deals with cases where an initial ticket was not created
+    if(is.na(db$rt_ticket[i])){
+      # Create RT ticket
+      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+      
+      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+        next 
+      }
+      
+    }
+    
     reply <- check_rt_reply(db$rt_ticket[i], email_text)
-
+    
     # Update last contact date
     db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
     
@@ -142,6 +153,17 @@ send_aon_correspondence <- function(awards_db, database_path){
     email_text <- sprintf(template,
                           db$pi_first_name[i])
     
+    #deals with cases where an initial ticket was not created
+    if(is.na(db$rt_ticket[i])){
+      # Create RT ticket
+      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+      
+      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+        next 
+      }
+      
+    }
+    
     reply <- check_rt_reply(db$rt_ticket[i], email_text)
     
     # Update last contact date
@@ -174,6 +196,16 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
                           db$pi_first_name[i],
                           db$id[i],
                           db$title[i])
+    
+    if(is.na(db$rt_ticket[i])){
+      # Create RT ticket
+      db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+      
+      if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+        next 
+      }
+      
+    }
     
     reply <- check_rt_reply(db$rt_ticket[i], email_text)
     
@@ -237,6 +269,25 @@ check_rt_reply <- function(ticket_number, email) {
   
   return(ticket)
 } 
+
+## helper function to 
+reply_rt_ticket <- function(){
+  
+  
+  if(is.na(db$rt_ticket[i])){
+    # Create RT ticket
+    db$rt_ticket[i] <- create_ticket(db$id[i], db$pi_email[i])
+    
+    if (db$rt_ticket[i] == 'rt_ticket_create_error') {
+      next 
+    }
+    
+    reply <- check_rt_reply(db$rt_ticket[i], email_text)
+    
+  } else {
+    reply <- check_rt_reply(db$rt_ticket[i], email_text)
+  }
+}
 
 ## helper function to read in email templates
 read_file <- function(path) {

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -79,7 +79,7 @@ create_ticket_and_send_initial_correspondence <- function(awards_db, database_pa
     db$contact_initial[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i,]
+    awards_db[indicies[i],] <- db[i,]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -112,7 +112,7 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
     db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -148,7 +148,7 @@ send_aon_correspondence <- function(awards_db, database_path){
     db$contact_aon_previous[i] <- db$contact_aon_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -181,7 +181,7 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
     db$contact_1mo[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[i,] <- db[i, ]
+    awards_db[indicies[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -79,7 +79,7 @@ create_ticket_and_send_initial_correspondence <- function(awards_db, database_pa
     db$contact_initial[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i,]
+    awards_db[indices[i],] <- db[i,]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -112,7 +112,7 @@ send_annual_report_correspondence <- function(awards_db, database_path) {
     db$contact_annual_report_previous[i] <- db$contact_annual_report_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -148,7 +148,7 @@ send_aon_correspondence <- function(awards_db, database_path){
     db$contact_aon_previous[i] <- db$contact_aon_next[i]
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }
@@ -181,7 +181,7 @@ send_one_month_remaining_correspondence <- function(awards_db, database_path) {
     db$contact_1mo[i] <- as.character(Sys.Date())
     
     # re-merge temporary database into permanent
-    awards_db[indicies[i],] <- db[i, ]
+    awards_db[indices[i],] <- db[i, ]
     #save the result inbetween
     utils::write.csv(awards_db, file = database_path, row.names = FALSE)
   }

--- a/R/RT_functions.R
+++ b/R/RT_functions.R
@@ -284,7 +284,7 @@ check_rt_login <- function(rt_base) {
 #' Similar to a mail merge for sending mass emails to RT.
 #'
 #' @param db (dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title
-#' @param template (character) an email template that will fill in the name and award title at each %s (see example below)
+#' @param template (character) an email template that will fill in the name and award title at each \%s (see example below)
 #' @param test (logical) sends a test email (replaces all the emails with a test email address)
 #' 
 #'

--- a/R/database_functions.R
+++ b/R/database_functions.R
@@ -1,13 +1,13 @@
-#' Import awards database 
-#' 
-#' Import awards database as an all-character data.frame. 
-#' 
-#' @param path (character) path to the awards database 
-#' 
+#' Import awards database
+#'
+#' Import awards database as an all-character data.frame.
+#'
+#' @param path (character) path to the awards database
+#'
 #' @export
 import_awards_db <- function(path) {
   tryCatch({
-    awards_db <- utils::read.csv(path) %>% 
+    awards_db <- utils::read.csv(path) %>%
       apply(2, as.character) %>% # force all fields into characters
       data.frame(stringsAsFactors = FALSE)
   },
@@ -19,59 +19,74 @@ import_awards_db <- function(path) {
 }
 
 #' Update Awards Database
-#' 
-#' Update the awards database with new awards information from the NSF API 
-#' (https://www.research.gov/common/webapi/awardapisearch-v1.htm) using 
+#'
+#' Update the awards database with new awards information from the NSF API
+#' (https://www.research.gov/common/webapi/awardapisearch-v1.htm) using
 #'
 #' @param awards_db (data.frame) awards database
-#' @param from_date (date) date to begin search from 
-#' @param to_date (date) date to end search at 
+#' @param from_date (date) date to begin search from
+#' @param to_date (date) date to end search at
 #'
 #' @export
 update_awards <- function(awards_db, from_date, to_date) {
-  
   ## format dates
   format <- '%m/%d/%Y'
   to_date <- format(as.Date(to_date), format)
   from_date <- format(as.Date(from_date), format)
   
   ## get new awards from NSF API
-  new_nsf_awards <- get_awards(from_date = from_date, to_date = to_date)
+  new_nsf_awards <-
+    get_awards(from_date = from_date, to_date = to_date)
   
   if (nrow(new_nsf_awards) > 0) {
-    colnames(new_nsf_awards) <- c('awardee', 'date', 'exp_date', 'fund_program_name',
-                                  'id', 'pi_email', 'pi_first_name', 'pi_last_name',
-                                  'pi_phone', 'po_name', 'start_date', 'title')
-    new_nsf_awards <- new_nsf_awards[!(new_nsf_awards$id %in% awards_db$id), ]
+    colnames(new_nsf_awards) <-
+      c(
+        'awardee',
+        'date',
+        'exp_date',
+        'fund_program_name',
+        'id',
+        'pi_email',
+        'pi_first_name',
+        'pi_last_name',
+        'pi_phone',
+        'po_name',
+        'start_date',
+        'title'
+      )
+    new_nsf_awards <-
+      new_nsf_awards[!(new_nsf_awards$id %in% awards_db$id),]
     
     ## combine awards
-    awards_db <- suppressWarnings(dplyr::bind_rows(awards_db, new_nsf_awards)) %>%
+    awards_db <-
+      suppressWarnings(dplyr::bind_rows(awards_db, new_nsf_awards)) %>%
       check_date_format()
   }
   
-  awards_db$active_award_flag <- ifelse(awards_db$exp_date >= Sys.Date(), 'yes', 'no')
+  awards_db$active_award_flag <-
+    ifelse(awards_db$exp_date >= Sys.Date(), 'yes', 'no')
   
   return(awards_db)
 }
 
 #' Update contact dates in awards database
-#' 
+#'
 #' Wrapper function for set_first_annual_report_due_date, update_annual_report_due_date
 #' set_first_aon_data_due_date, update_aon_data_due_date
-#' 
+#'
 #' @param awards_db (data.frame) awards database
 #' @param annual_report_time (numeric) time in months after 'start_date' to send the first annual report reminder
 #' @param initial_aon_offset (numeric) time in months after 'start_date' to send the first aon data reminder
 #' @param aon_recurring_interval (numeric) time in months to send aon data recurring reminders
-#' 
+#'
 #' @importFrom magrittr '%>%'
 #' @importFrom lubridate '%m+%'
 update_contact_dates <- function(awards_db,
                                  annual_report_time,
                                  initial_aon_offset,
                                  aon_recurring_interval) {
-  indices <- which(awards_db$active_award_flag == 'yes') 
-  db <- awards_db[indices,]
+  indices <- which(awards_db$active_award_flag == 'yes')
+  db <- awards_db[indices, ]
   
   db <- set_first_annual_report_due_date(db, annual_report_time) %>%
     update_annual_report_due_date() %>%
@@ -79,69 +94,84 @@ update_contact_dates <- function(awards_db,
     update_aon_data_due_date(aon_recurring_interval) %>%
     set_one_month_remaining_date()
   
-  awards_db[indices,] <- db
+  awards_db[indices, ] <- db
   
   return(awards_db)
+  
 }
 
 
-set_first_annual_report_due_date <- function(awards_db, annual_report_time) {
-  indices <- which(is.na(awards_db$contact_annual_report_next))
-  db <- awards_db[indices,]
-  
-  # Initialize first annual report as 'annual_report_time' months after 'start_date'
-  start_date <- lubridate::ymd(db$start_date)
-  db$contact_annual_report_next <- start_date %m+% months(annual_report_time) %>%
-    as.character()
-  
-  awards_db[indices,] <- db
-  
-  return(awards_db)
-}
+set_first_annual_report_due_date <-
+  function(awards_db, annual_report_time) {
+    indices <- which(is.na(awards_db$contact_annual_report_next))
+    db <- awards_db[indices, ]
+    
+    # Initialize first annual report as 'annual_report_time' months after 'start_date'
+    start_date <- lubridate::ymd(db$start_date)
+    db$contact_annual_report_next <-
+      start_date %m+% months(annual_report_time) %>%
+      as.character()
+    
+    awards_db[indices, ] <- db
+    
+    return(awards_db)
+  }
 
 
 update_annual_report_due_date <- function(awards_db) {
-  indices <- which(awards_db$contact_annual_report_previous == awards_db$contact_annual_report_next)
-  db <- awards_db[indices,]
+  indices <-
+    which(
+      awards_db$contact_annual_report_previous == awards_db$contact_annual_report_next
+    )
+  db <- awards_db[indices, ]
   
   # Set next annual report date ahead 1 year
   date <- lubridate::ymd(db$contact_annual_report_next)
   db$contact_annual_report_next <- (date + lubridate::years(1)) %>%
     as.character()
   
-  awards_db[indices,] <- db
+  awards_db[indices, ] <- db
   
   return(awards_db)
 }
 
 
-set_first_aon_data_due_date <- function(awards_db, initial_aon_offset){
-  indices <- which((is.na(awards_db$contact_aon_next) & grepl('AON', awards_db$fund_program_name)))
-  db <- awards_db[indices,]
-  
-  # Initialize first aon submissions as 'initial_aon_offset' months after 'start_date'
-  start_date <- lubridate::ymd(db$start_date)
-  db$contact_aon_next <- start_date %m+% months(initial_aon_offset) %>%
-    as.character()
-  
-  awards_db[indices,] <- db
-  
-  return(awards_db)
-}
+set_first_aon_data_due_date <-
+  function(awards_db, initial_aon_offset) {
+    indices <-
+      which((
+        is.na(awards_db$contact_aon_next) &
+          grepl('AON', awards_db$fund_program_name)
+      ))
+    db <- awards_db[indices, ]
+    
+    # Initialize first aon submissions as 'initial_aon_offset' months after 'start_date'
+    start_date <- lubridate::ymd(db$start_date)
+    db$contact_aon_next <-
+      start_date %m+% months(initial_aon_offset) %>%
+      as.character()
+    
+    awards_db[indices, ] <- db
+    
+    return(awards_db)
+  }
 
-update_aon_data_due_date <- function(awards_db, aon_recurring_interval) {
-  indices <- which(awards_db$contact_aon_previous == awards_db$contact_aon_next)
-  db <- awards_db[indices,]
-  
-  # Set next aon data due date ahead 'aon_recurring_interval' months
-  date <- lubridate::ymd(db$contact_aon_next)
-  db$contact_aon_next <- (date %m+% months(aon_recurring_interval)) %>%
-    as.character()
-  
-  awards_db[indices,] <- db
-  
-  return(awards_db)
-}
+update_aon_data_due_date <-
+  function(awards_db, aon_recurring_interval) {
+    indices <-
+      which(awards_db$contact_aon_previous == awards_db$contact_aon_next)
+    db <- awards_db[indices, ]
+    
+    # Set next aon data due date ahead 'aon_recurring_interval' months
+    date <- lubridate::ymd(db$contact_aon_next)
+    db$contact_aon_next <-
+      (date %m+% months(aon_recurring_interval)) %>%
+      as.character()
+    
+    awards_db[indices, ] <- db
+    
+    return(awards_db)
+  }
 
 set_one_month_remaining_date <- function(awards_db) {
   exp_date <- lubridate::ymd(awards_db$exp_date)
@@ -157,31 +187,35 @@ set_one_month_remaining_date <- function(awards_db) {
 # potentially there is a more elegant solution than the one here
 # Forcing date columns to y-m-d
 check_date_format <- function(awards_db) {
-  is_date <- which(colnames(awards_db) %in% c('date',
-                                              'exp_date',
-                                              'start_date',
-                                              'contact_initial',
-                                              'contact_annual_report_previous',
-                                              'contact_annual_report_next',
-                                              'contact_aon_previous',
-                                              'contact_aon_next',
-                                              'contact_3mo'))
+  is_date <- which(
+    colnames(awards_db) %in% c(
+      'date',
+      'exp_date',
+      'start_date',
+      'contact_initial',
+      'contact_annual_report_previous',
+      'contact_annual_report_next',
+      'contact_aon_previous',
+      'contact_aon_next',
+      'contact_3mo'
+    )
+  )
   
-  awards_db[, is_date] <- apply(awards_db[, is_date], c(1,2), function(x){
-    if (!is.na(x)) {  
-      
-      ## if not NA try to reformat date from m-d-y to y-m-d
-      ## TODO need to test edge cases to ensure this always works
-      tryCatch({
-        paste0(lubridate::mdy(x))
-      }, warning = function(w) {
-        x
-      })
-      
-    } else {
-      NA
-    }
-  })
+  awards_db[, is_date] <-
+    apply(awards_db[, is_date], c(1, 2), function(x) {
+      if (!is.na(x)) {
+        ## if not NA try to reformat date from m-d-y to y-m-d
+        ## TODO need to test edge cases to ensure this always works
+        tryCatch({
+          paste0(lubridate::mdy(x))
+        }, warning = function(w) {
+          x
+        })
+        
+      } else {
+        NA
+      }
+    })
   
   return(awards_db)
 }
@@ -189,12 +223,16 @@ check_date_format <- function(awards_db) {
 
 get_lastrun <- function(path) {
   lastrun <- NULL
-
+  
   if (file.exists(path)) {
     lastrun <- as.Date(readLines(path, n = 1))
-  } 
+  }
   if (is.null(lastrun)) {
-    out <- sprintf('I failed to read in my LASTRUN time. Check that %s exists. Setting LASTRUN to Sys.Date()', path)
+    out <-
+      sprintf(
+        'I failed to read in my LASTRUN time. Check that %s exists. Setting LASTRUN to Sys.Date()',
+        path
+      )
     slackr::slackr_bot(out)
     lastrun <- Sys.Date()
   }
@@ -208,11 +246,11 @@ save_lastrun <- function(lastrun, path) {
 }
 
 
-#' Get NSF Arctic/Polar program award information.  
+#' Get NSF Arctic/Polar program award information.
 #'
 #' Uses the \href{https://www.research.gov/common/webapi/awardapisearch-v1.htm}{NSF API}
 #' to get all records pertaining to the Arctic or Polar programs. Originally in the
-#' 'NCEAS/datamgmt' package.  Added to this repo because the import of datamgmt is too costly.  
+#' 'NCEAS/datamgmt' package.  Added to this repo because the import of datamgmt is too costly.
 #'
 #' @param from_date (character) Optional. Returns all
 #' records with start date after specified date.
@@ -263,28 +301,30 @@ get_awards <- function(from_date = NULL,
   stopifnot(is.character(query) | is.null(query))
   stopifnot(is.character(print_fields) | is.null(print_fields))
   
-  base_url <- 'https://api.nsf.gov/services/v1/awards.xml?fundProgramName=ARCTIC|fundProgramName=POLAR|fundProgramName=AON'
-  if(!is.null(query)) {
+  base_url <-
+    'https://api.nsf.gov/services/v1/awards.xml?fundProgramName=ARCTIC|fundProgramName=POLAR|fundProgramName=AON'
+  if (!is.null(query)) {
     query <- paste0('&', query)
   }
   
-  if(is.null(print_fields)) {
-    print_fields <- 'id,date,startDate,expDate,fundProgramName,poName,title,awardee,piFirstName,piLastName,piPhone,piEmail'
+  if (is.null(print_fields)) {
+    print_fields <-
+      'id,date,startDate,expDate,fundProgramName,poName,title,awardee,piFirstName,piLastName,piPhone,piEmail'
   }
   
   query_url <- paste0(base_url, query,
                       '&printFields=', print_fields)
   
-  if(!is.null(from_date)) {
-    if(!stringr::str_detect(from_date, '\\d\\d/\\d\\d/\\d\\d\\d\\d')) {
+  if (!is.null(from_date)) {
+    if (!stringr::str_detect(from_date, '\\d\\d/\\d\\d/\\d\\d\\d\\d')) {
       stop('The from_date is not in the format "mm/dd/yyyy".')
     } else {
       query_url <- paste0(query_url, '&dateStart=', from_date)
     }
   }
   
-  if(!is.null(to_date)) {
-    if(!stringr::str_detect(to_date, '\\d\\d/\\d\\d/\\d\\d\\d\\d')) {
+  if (!is.null(to_date)) {
+    if (!stringr::str_detect(to_date, '\\d\\d/\\d\\d/\\d\\d\\d\\d')) {
       stop('The to_date is not in the format "mm/dd/yyyy".')
     } else {
       query_url <- paste0(query_url, '&dateEnd=', to_date)
@@ -292,7 +332,7 @@ get_awards <- function(from_date = NULL,
   }
   
   xml1 <- RCurl::getURL(paste0(query_url, '&offset=', 1))
-  if(stringr::str_detect(xml1, 'ERROR')){
+  if (stringr::str_detect(xml1, 'ERROR')) {
     stop('The query parameters are invalid.')
   }
   xml_df1 <- XML::xmlToDataFrame(xml1, stringsAsFactors = FALSE)
@@ -303,11 +343,14 @@ get_awards <- function(from_date = NULL,
     start <- 1 + 25 * n
     xml <- RCurl::getURL(paste0(query_url, '&offset=', start))
     xml_df <- XML::xmlToDataFrame(xml, stringsAsFactors = FALSE)
-    if (length(xml_df) == 0) {break}
+    if (length(xml_df) == 0) {
+      break
+    }
     
     #check column names, add in missing one
-    missing <- colnames(xml_df1)[!colnames(xml_df1) %in% colnames(xml_df)]
-    if(length(missing) > 0){
+    missing <-
+      colnames(xml_df1)[!colnames(xml_df1) %in% colnames(xml_df)]
+    if (length(missing) > 0) {
       xml_df[[missing]] <- NA
     }
     
@@ -320,4 +363,4 @@ get_awards <- function(from_date = NULL,
 
 # TODO make a check_database() function
 ## can't have any NA db$exp_date values, or start_date
-# - probably can't have any NA date values for functions to work 
+# - probably can't have any NA date values for functions to work

--- a/R/main.R
+++ b/R/main.R
@@ -7,7 +7,7 @@
 #' @param initial_aon_offset (numeric)Number of months after award startDate to send first AON data due reminder
 #' @param aon_recurring_interval (numeric) Number of months to send recurring emails for AON data due
 #'
-#' @return
+#' @return nothing
 #' @export
 #'
 #' @examples
@@ -53,7 +53,7 @@ main <- function(database_path = Sys.getenv('DATABASE_PATH'),
 #' @param aon_recurring_interval (numeric) Number of months to send recurring emails for AON data due
 #' @param email The email to send the tickets to
 #'
-#' @return
+#' @return nothing
 #' @export
 #'
 #' @examples

--- a/R/main.R
+++ b/R/main.R
@@ -17,32 +17,35 @@ main <- function(database_path = Sys.getenv('DATABASE_PATH'),
                  annual_report_time = Sys.getenv('ANNUAL_REPORT_TIME'),
                  initial_aon_offset = Sys.getenv('INITIAL_AON_OFFSET'),
                  aon_recurring_interval = Sys.getenv('AON_RECURRING_INTERVAL')) {
-  
   annual_report_time <-  as.numeric(annual_report_time)
   initial_aon_offset <-  as.numeric(initial_aon_offset)
   aon_recurring_interval <-  as.numeric(aon_recurring_interval)
   
   
-  ## Import awards database 
+  ## Import awards database
   db <- import_awards_db(database_path)
   
-  ## Update awards database 
+  ## Update awards database
   lastrun <- get_lastrun(lastrun_path)
   db <- update_awards(db, lastrun, current_date)
-  db <- update_contact_dates(db, annual_report_time, initial_aon_offset, aon_recurring_interval) 
+  db <-
+    update_contact_dates(db,
+                         annual_report_time,
+                         initial_aon_offset,
+                         aon_recurring_interval)
   
-  ## Send correspondences 
+  ## Send correspondences
   send_correspondences(db, database_path)
   
-  ## Save lastrun and database 
+  ## Save lastrun and database
   save_lastrun(current_date, lastrun_path)
   
   return(invisible())
 }
 
-# 
+#
 #' Test main function
-#' Wrapper for main, with additional email testing argument. 
+#' Wrapper for main, with additional email testing argument.
 #' Uses a dummy database that will send out 2 tickets using the email specified
 #'
 #' @param database_path (character) Path to the database of awards and correspondences
@@ -64,21 +67,25 @@ test_main <- function(database_path = Sys.getenv('DATABASE_PATH'),
                       initial_aon_offset = Sys.getenv('INITIAL_AON_OFFSET'),
                       aon_recurring_interval = Sys.getenv('AON_RECURRING_INTERVAL'),
                       email) {
-  
   annual_report_time <-  as.numeric(annual_report_time)
   initial_aon_offset <-  as.numeric(initial_aon_offset)
   aon_recurring_interval <-  as.numeric(aon_recurring_interval)
   
-  # Change email to testing email 
+  # Change email to testing email
   db <- import_awards_db(database_path)
   db$pi_email <- email
   utils::write.csv(db, database_path, row.names = FALSE)
   
-  main(database_path = database_path, lastrun_path = lastrun_path, current_date = current_date,
-       annual_report_time = annual_report_time, initial_aon_offset = initial_aon_offset,
-       aon_recurring_interval = aon_recurring_interval)
+  main(
+    database_path = database_path,
+    lastrun_path = lastrun_path,
+    current_date = current_date,
+    annual_report_time = annual_report_time,
+    initial_aon_offset = initial_aon_offset,
+    aon_recurring_interval = aon_recurring_interval
+  )
   
 }
 
-## Run a separate cron bot that notifies with correspondences 
-## include some logic to only run this when Sys.Date() changes, the rest can run every 15 minutes.  
+## Run a separate cron bot that notifies with correspondences
+## include some logic to only run this when Sys.Date() changes, the rest can run every 15 minutes.

--- a/R/testing_functions.R
+++ b/R/testing_functions.R
@@ -1,28 +1,30 @@
-## Testing functions 
+## Testing functions
 
 create_blank_database <- function() {
-  col_names <- c('awardee',
-                 'date',
-                 'exp_date',
-                 'fund_program_name',
-                 'id',
-                 'pi_email',
-                 'pi_first_name',
-                 'pi_last_name',
-                 'pi_phone',
-                 'po_name',
-                 'start_date',
-                 'title',
-                 'rt_ticket',
-                 'pi_orcid',
-                 'contact_initial',
-                 'contact_annual_report_previous',
-                 'contact_annual_report_next',
-                 'contact_aon_previous',
-                 'contact_aon_next',
-                 'contact_1mo',
-                 'active_award_flag')
-   
+  col_names <- c(
+    'awardee',
+    'date',
+    'exp_date',
+    'fund_program_name',
+    'id',
+    'pi_email',
+    'pi_first_name',
+    'pi_last_name',
+    'pi_phone',
+    'po_name',
+    'start_date',
+    'title',
+    'rt_ticket',
+    'pi_orcid',
+    'contact_initial',
+    'contact_annual_report_previous',
+    'contact_annual_report_next',
+    'contact_aon_previous',
+    'contact_aon_next',
+    'contact_1mo',
+    'active_award_flag'
+  )
+  
   blank_db <- data.frame(matrix(ncol = length(col_names), nrow = 1))
   colnames(blank_db) <- col_names
   
@@ -39,13 +41,14 @@ write_blank_database <- function(path) {
   return(invisible())
 }
 
-## TODO - this doesn't appear to work properly 
+## TODO - this doesn't appear to work properly
 write_inst_database <- function() {
   db <- create_blank_database() %>%
-    update_awards(from_date = as.Date('2018-06-28'), to_date = as.Date('2018-07-05')) %>%
+    update_awards(from_date = as.Date('2018-06-28'),
+                  to_date = as.Date('2018-07-05')) %>%
     check_date_format() %>%
-    apply(2, as.character) 
-  utils::write.csv(db[2:3,], file.path(system.file('example_db.csv', package = 'awardsBot')),
+    apply(2, as.character)
+  utils::write.csv(db[2:3, ], file.path(system.file('example_db.csv', package = 'awardsBot')),
                    row.names = FALSE)
 }
 
@@ -58,12 +61,12 @@ create_dummy_database <- function() {
   db$pi_last_name <- 'Mullen'
   db$title <- '**Test** AwardBot Title'
   db$fund_program_name <- 'ARCTIC NATURAL SCIENCES'
-  db$id <- '1234567'  # NSF award number 
+  db$id <- '1234567'  # NSF award number
   db$start_date <- '2016-01-01'
   db$active_award_flag <- "no"
   
   #make 2  more rows
-  db <- rbind(db[1,], db[1,], db[1,])
+  db <- rbind(db[1, ], db[1, ], db[1, ])
   
   db$id[1] <- "7654321"
   db$id[3] <- "9999999"
@@ -80,4 +83,3 @@ with_dir <- function(directory, expr) {
   setwd(directory)
   evalq(expr)
 }
-

--- a/R/testing_functions.R
+++ b/R/testing_functions.R
@@ -65,10 +65,10 @@ create_dummy_database <- function() {
   #make 2  more rows
   db <- rbind(db[1,], db[1,], db[1,])
   
-  db$id[2] <- "7654321"
+  db$id[1] <- "7654321"
   db$id[3] <- "9999999"
   
-  db$active_award_flag[1] <- "yes"
+  db$active_award_flag[2] <- "yes"
   
   return(db)
 }

--- a/R/testing_functions.R
+++ b/R/testing_functions.R
@@ -60,6 +60,15 @@ create_dummy_database <- function() {
   db$fund_program_name <- 'ARCTIC NATURAL SCIENCES'
   db$id <- '1234567'  # NSF award number 
   db$start_date <- '2016-01-01'
+  db$active_award_flag <- "no"
+  
+  #make 2  more rows
+  db <- rbind(db[1,], db[1,], db[1,])
+  
+  db$id[2] <- "7654321"
+  db$id[3] <- "9999999"
+  
+  db$active_award_flag[1] <- "yes"
   
   return(db)
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The NSF awards bot regularly contacts principal investigators with reminders on their project specific deadlines.  Please read the [schedule readme](https://github.com/NCEAS/awards-bot/tree/master/inst/emails) for more detailed information on automated correspondences.
 
 ## How the bot works 
-Every 24 hours the bot queries NSF's award [API](https://www.research.gov/common/webapi/awardapisearch-v1.htm) for newly awarded grants and stores this information in a pre-existing database.  When it finds a new award it creates a new ticket in [Request Tracker](https://bestpractical.com/request-tracker/) and sends an initial correspondence that outlines project-specific expectations and deadlines.  It sends reminders to submit annual reports, submit data for Arctic Observing Network (AON) projects, and that the award is expiring soon.  The bot sends error messages to a slack channel. 
+Every 24 hours the bot queries NSF's award [API](https://www.research.gov/common/webapi/awardapisearch-v1.htm) for newly awarded grants and stores this information in a pre-existing database.  When it finds a new award it creates a new ticket in [Request Tracker](https://bestpractical.com/request-tracker/) and sends an initial correspondence that outlines project-specific expectations and deadlines.  It sends reminders to submit annual reports, submit data for Arctic Observing Network (AON) projects, and that the award is expiring soon.  The bot sends a summary of the number of each type of correspondence sent and error messages to a slack channel. 
 
 ## Setup
 - Copy the bot [cron script](https://github.com/NCEAS/awards-bot/blob/master/inst/main_cron_script.R) to a directory 
@@ -24,7 +24,7 @@ Every 24 hours the bot queries NSF's award [API](https://www.research.gov/common
   AON_RECURRING_INTERVAL=6                 # Number of months to send recurring emails for AON data due
   ```
 
-**Note** - please contact Chris for set up in Linux
+- see the `server` vignette for more details
 
 ## Running 
 Run the bot [cron script](https://github.com/NCEAS/awards-bot/blob/master/inst/main_cron_script.R) every 24 hours.    

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -23,10 +23,10 @@ Similar to a mail merge for sending mass emails to RT.
 \examples{
 \dontrun{
 db <- import_awards_db(file.path(system.file('example_db.csv', package = 'awardsBot')))
+email_text <-  "Dear \%s,  \n We are writing to you today about your NSF Arctic Sciences award \%s \%s. 
+                \n The Arctic Data Center Support Team"
 create_new_ticket_correspondence(db = db, 
-                                 "Dear \%s, 
-                                 \n We are writing to you today about your NSF Arctic Sciences award \%s \%s. 
-                                 \n The Arctic Data Center Support Team", 
-                                 test = TRUE)
+                                email_text, 
+                                test = TRUE)
 }
 }

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -2,14 +2,14 @@
 % Please edit documentation in R/RT_functions.R
 \name{create_new_ticket_correspondence}
 \alias{create_new_ticket_correspondence}
-\title{Generalized version of the create_ticket and send correspondence function}
+\title{Generalized version of the create_ticket and send_correspondences function}
 \usage{
 create_new_ticket_correspondence(db, template, test = TRUE)
 }
 \arguments{
 \item{db}{(dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title}
 
-\item{template}{(character)}
+\item{template}{(character) an email template that will fill in the name and award title at each %s (see example below)}
 
 \item{test}{(logical) sends a test email (replaces all the emails with a test email address)}
 }

--- a/man/create_new_ticket_correspondence.Rd
+++ b/man/create_new_ticket_correspondence.Rd
@@ -9,7 +9,7 @@ create_new_ticket_correspondence(db, template, test = TRUE)
 \arguments{
 \item{db}{(dataframe) a database containing the name and email for follow up with the following column named: first_name, id, title}
 
-\item{template}{(character) an email template that will fill in the name and award title at each %s (see example below)}
+\item{template}{(character) an email template that will fill in the name and award title at each \%s (see example below)}
 
 \item{test}{(logical) sends a test email (replaces all the emails with a test email address)}
 }

--- a/man/main.Rd
+++ b/man/main.Rd
@@ -27,7 +27,7 @@ main(
 \item{aon_recurring_interval}{(numeric) Number of months to send recurring emails for AON data due}
 }
 \value{
-
+nothing
 }
 \description{
 main function

--- a/man/test_main.Rd
+++ b/man/test_main.Rd
@@ -32,7 +32,7 @@ test_main(
 \item{email}{The email to send the tickets to}
 }
 \value{
-
+nothing
 }
 \description{
 Test main function

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -14,7 +14,7 @@ test_that('we can create an RT ticket', {
   db <- create_dummy_database()
   
   #does not return ticket but creates ticket
-  ticket <- create_ticket(db$id, db$pi_email)
+  ticket <- create_ticket(db$id[1], db$pi_email[1])
   
   expect_type(ticket, 'double')
 })
@@ -41,12 +41,12 @@ test_that('we can send an annual report correspondence', {
   db$contact_annual_report_next[2] <- as.character(Sys.Date())
   db <- send_annual_report_correspondence(db, database_path = db_path)
   
-  #No previous ticket
+  #Scenario where there is no previous ticket
   expect_type(db$rt_ticket[2], "double")
   
   db <- send_annual_report_correspondence(db, database_path = db_path)
   
-  #has a RT ticket already
+  #Scenario where there is a RT ticket already
   expect_equal(db$contact_annual_report_next[2], db$contact_annual_report_previous[2])
 })
 
@@ -60,12 +60,12 @@ test_that('we can send a one month remaining correspondence',{
   # Set expiration date to one month from now
   db$contact_1mo <- as.character(Sys.Date())
   
-  #No previous ticket
+  #Scenario where there is no previous ticket
   db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
   expect_type(db$rt_ticket[2], "double")
   
-  #has a RT ticket already
+  #Scenario where there is a RT ticket already
   db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_1mo[2], as.character(Sys.Date()))
@@ -79,11 +79,12 @@ test_that('we can send an aon correspondence', {
   db <- create_dummy_database()
   db$contact_aon_next[2] <- as.character(Sys.Date())
   
-  #No previous ticket
+  #Scenario where there is no previous ticket
   db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_type(db$rt_ticket[2], "double")
   
+  #Scenario where there is a previous ticket
   db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -38,10 +38,15 @@ test_that('we can send an annual report correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_annual_report_next[2] <- as.character(Sys.Date())
   db <- send_annual_report_correspondence(db, database_path = db_path)
   
+  #No previous ticket
+  expect_type(db$rt_ticket[2], "double")
+  
+  db <- send_annual_report_correspondence(db, database_path = db_path)
+  
+  #has a RT ticket already
   expect_equal(db$contact_annual_report_next[2], db$contact_annual_report_previous[2])
 })
 
@@ -54,6 +59,13 @@ test_that('we can send a one month remaining correspondence',{
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   # Set expiration date to one month from now
   db$contact_1mo <- as.character(Sys.Date())
+  
+  #No previous ticket
+  db <- send_one_month_remaining_correspondence(db, database_path = db_path)
+  
+  expect_type(db$rt_ticket[2], "double")
+  
+  #has a RT ticket already
   db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_1mo[2], as.character(Sys.Date()))
@@ -65,8 +77,13 @@ test_that('we can send an aon correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_aon_next[2] <- as.character(Sys.Date())
+  
+  #No previous ticket
+  db <- send_aon_correspondence(db, database_path = db_path)
+  
+  expect_type(db$rt_ticket[2], "double")
+  
   db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -2,6 +2,7 @@ library(rt)
 context('Send RT correspondences')
 
 rt_url <- 'https://support.nceas.ucsb.edu/rt'
+db_path<- tempfile()
 
 ## TODO these tests could be improved with an rt::get_last_correspondence_text function
 
@@ -25,7 +26,7 @@ test_that('we can send an initial correspondence', {
   
   db <- create_dummy_database()
 
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
   ticket <- rt::rt_ticket_properties(db$rt_ticket)
   expect_equal(ticket$Requestors, 'jasminelai@nceas.ucsb.edu')
@@ -37,9 +38,9 @@ test_that('we can send an annual report correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_annual_report_next <- as.character(Sys.Date())
-  db <- send_annual_report_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_annual_report_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_annual_report_next, db$contact_annual_report_previous)
 })
@@ -50,10 +51,10 @@ test_that('we can send a one month remaining correspondence',{
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   # Set expiration date to one month from now
   db$contact_1mo <- as.character(Sys.Date())
-  db <- send_one_month_remaining_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_1mo, as.character(Sys.Date()))
 })
@@ -64,9 +65,9 @@ test_that('we can send an aon correspondence', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   db$contact_aon_next <- as.character(Sys.Date())
-  db <- send_aon_correspondence(db, database_path = "inst/test_db.csv")
+  db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)
 })
@@ -81,7 +82,7 @@ test_that('check_rt_reply catches both potential errors', {
   }
   
   db <- create_dummy_database()
-  db <- create_ticket_and_send_initial_correspondence(db, database_path = "inst/test_db.csv")
+  db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
   template <- read_initial_template(db$fund_program_name[1])
   email_text <- sprintf(template,

--- a/tests/testthat/test_RT_functions.R
+++ b/tests/testthat/test_RT_functions.R
@@ -28,7 +28,7 @@ test_that('we can send an initial correspondence', {
 
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
   
-  ticket <- rt::rt_ticket_properties(db$rt_ticket)
+  ticket <- rt::rt_ticket_properties(db$rt_ticket[2])
   expect_equal(ticket$Requestors, 'jasminelai@nceas.ucsb.edu')
 })
 
@@ -39,10 +39,10 @@ test_that('we can send an annual report correspondence', {
   
   db <- create_dummy_database()
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
-  db$contact_annual_report_next <- as.character(Sys.Date())
+  db$contact_annual_report_next[2] <- as.character(Sys.Date())
   db <- send_annual_report_correspondence(db, database_path = db_path)
   
-  expect_equal(db$contact_annual_report_next, db$contact_annual_report_previous)
+  expect_equal(db$contact_annual_report_next[2], db$contact_annual_report_previous[2])
 })
 
 test_that('we can send a one month remaining correspondence',{
@@ -56,7 +56,7 @@ test_that('we can send a one month remaining correspondence',{
   db$contact_1mo <- as.character(Sys.Date())
   db <- send_one_month_remaining_correspondence(db, database_path = db_path)
   
-  expect_equal(db$contact_1mo, as.character(Sys.Date()))
+  expect_equal(db$contact_1mo[2], as.character(Sys.Date()))
 })
 
 test_that('we can send an aon correspondence', {
@@ -66,7 +66,7 @@ test_that('we can send an aon correspondence', {
   
   db <- create_dummy_database()
   db <- create_ticket_and_send_initial_correspondence(db, database_path = db_path)
-  db$contact_aon_next <- as.character(Sys.Date())
+  db$contact_aon_next[2] <- as.character(Sys.Date())
   db <- send_aon_correspondence(db, database_path = db_path)
   
   expect_equal(db$contact_aon_previous, db$contact_aon_next)

--- a/vignettes/server.Rmd
+++ b/vignettes/server.Rmd
@@ -58,6 +58,8 @@ For more info see the [Git basis -Tagging](https://git-scm.com/book/en/v2/Git-Ba
 install_github("NCEAS/awards-bot@version_number")
 ```
 
+**Note** - the way this package is named is inconsistent - the package is call `awardsBot` while the repository is `awards-bot`
+
 4. unzip the file:
 ```{bash}
 unzip awards-bot-verion.zip


### PR DESCRIPTION
In cases where we skipped the initial email (the reasonable window of sending the initial email has passed such as half a year to a year since the award has been issued), still allow the bot to email reminder emails.