### PR TITLE
make sure the award information is unique

### DIFF
--- a/R/database_functions.R
+++ b/R/database_functions.R
@@ -315,7 +315,7 @@ get_awards <- function(from_date = NULL,
     n <- n + 1
   }
   
-  return(xml_df1)
+  return(dplyr::distinct(xml_df1, id, .keep_all = T))
 }
 
 # TODO make a check_database() function

--- a/tests/testthat/test_database_functions.R
+++ b/tests/testthat/test_database_functions.R
@@ -78,8 +78,12 @@ test_that('we can save the last time the bot ran', {
   expect_equal(readLines(file_path), 'text to save')
 })
 
+test_that('get award works and does not produce duplicates', {
+  nsf_awards <- awardsBot::get_awards(from_date = '06/25/2021', to_date = "09/02/2021")
+  
+  expect_equal(nsf_awards$id, unique(nsf_awards$id))
+})
+
 test_that('update_contact_dates wrapper works', {})
-
-
 
 


### PR DESCRIPTION
make sure the award information retrieved using the NSF award API is unique before adding it to the awards database